### PR TITLE
Implemented take_turn function

### DIFF
--- a/hog.py
+++ b/hog.py
@@ -42,7 +42,16 @@ def take_turn(num_rolls, opponent_score, dice=six_sided):
     assert num_rolls >= 0, 'Cannot roll a negative number of dice.'
     assert num_rolls <= 10, 'Cannot roll more than 10 dice.'
     assert opponent_score < 100, 'The game should be over.'
-    "*** YOUR CODE HERE ***"
+
+    if num_rolls == 0:
+        try:
+            max_digit = max(str(opponent_score)[0],str(opponent_score)[1])
+        except IndexError:
+            max_digit = str(opponent_score)
+        free_bacon = int(max_digit) + 1
+        return free_bacon
+    else:
+        return roll_dice(num_rolls, dice)
 
 # Playing a game
 


### PR DESCRIPTION
@Kally95 Checkout the description for Problem #2. The following function solution to implement a player taking a turn checks if they are using the "free bacon" rule, in which case they do not roll and instead take one more than the number of the opponent score's highest digit. 

This part of the function also checks if the opponent's score is less than 2 digits, in which case it will always be 1 more than their current score. This is shown in the last test case in test suite 1 of the hog_grader: `((0,  7), 8)`. The test case has two elements stored in a tuple, the `input` and `output`. The `input` is broken up into another variable length tuple. In this case it is `num_rolls` (0) and `opponent_score` (7). The expected `output` is 8.

If the player chooses to roll the dice, instead, then the number of rolls they chose (which must be less than 10) is passed to the `roll_dice` function.