### PR TITLE
Added fix to roll_dice so it would pass hog grader tests

### DIFF
--- a/hog.py
+++ b/hog.py
@@ -21,13 +21,17 @@ def roll_dice(num_rolls, dice=six_sided):
     # These assert statements ensure that num_rolls is a positive integer.
     assert type(num_rolls) == int, 'num_rolls must be an integer.'
     assert num_rolls > 0, 'Must roll at least once.'
+    
     sum = 0
-    for roll in range(num_rolls):
+    pig_out = False
+    for _ in range(num_rolls):
         roll = dice()
         if roll == 1:
-            return 1
+            pig_out = True
         sum += roll
     
+    if pig_out:
+        sum = 1
     return sum
 
 


### PR DESCRIPTION
@Kally95 I followed the code for the `hog_grader` file into the test decorator that the automated tests are using (recall [Chapter 1.6.9 of Composing Programs](https://composingprograms.com/pages/16-higher-order-functions.html#function-decorators)) to better understand the test case format of the test that it was failing: `(1, counted_dice), 4)`.

As mentioned in the take_turn PR, the test case has two elements stored in a tuple, the `input` and `output`. The `input` is broken up into another variable length tuple. In this case it is `num_rolls` (1) and `dice` (counted_dice). The variable `counted_dice` is set to the output of `make_test_dice(4, 1, 2)`.  Recall that `make_test_dice` is a function defined in the `dice.py` module

Remember that in Python functions are considered "first-class", and relevant to this specific case in Chapter 1.6.8 of CP #3, "They may be returned as the results of functions." with an example in [Chapter 1.6.4 of CP](https://composingprograms.com/pages/16-higher-order-functions.html#functions-as-returned-values). Therefore, this test case and any other test case that uses `counted_dice` as `input` before or after it will continuously cycle through the same input, which is 4, 1, and 2.

The expected `output` of this test case is  is 4, rather than the sides of the dice that we initially thought. Our first attempt at the function was returning 2 instead of 4, as noted in our test failure report, because the function was immediately returning when the number `1` came up as a dice roll. The part we missed from the question was this important line from the instruction in order to pass the test suite: "This calls DICE exactly NUM_ROLLS times.". When we returned the function too early, `roll_dice` was not calling `dice()` the same number of times as `num_rolls` and therefore the current place of the determined dice from `make_test_dice` would be at the wrong index when used in a subsequent test case.

Additionally, I edited renamed the unused variable in the for loop with an underscore, as is convention in Python (PEP8).

PM if you have any questions! 